### PR TITLE
[CHORE] Update README example for repeated comparisons

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,22 +19,36 @@ pak::pkg_install("ddarmon/regressr")
 ```r
 library(regressr)
 
-# Compare `main()` results between two SHAs of "org/pkg"
-res <- sha_compare(
-  repo = "org/pkg",
-  sha_old = "abc123",   # base commit
-  sha_new = "def456",   # comparison commit
-  pkg = "pkg",
-  entry_fun = "main",
-  data = data.frame(x = 1:3)
-)
+# Directories used to install the package versions
+old_lib <- tempfile("regressr_old_")
+new_lib <- tempfile("regressr_new_")
+dir.create(old_lib)
+dir.create(new_lib)
 
-if (res$passed) {
-  print("Objects identical")
-} else {
-  print(res$diff)
+# SHAs to compare against a baseline commit
+shas <- c("def456", "ghi789")
+for (i in seq_along(shas)) {
+  res <- sha_compare(
+    repo = "org/pkg",
+    sha_old = "abc123",   # baseline commit
+    sha_new = shas[i],     # comparison commit
+    pkg = "pkg",
+    entry_fun = "main",
+    data = data.frame(x = 1:3),
+    old_lib = old_lib,
+    new_lib = new_lib,
+    install = i == 1,      # reuse installs after first iteration
+    quiet = TRUE
+  )
+
+  if (res$passed) {
+    print("Objects identical")
+  } else {
+    print(res$diff)
+  }
 }
 ```
 
-The object returned by `sha_compare()` includes whether the objects are
-identical (`passed`) as well as the two results and their diff.
+Reusing the library directories and setting `install = FALSE` after the first
+iteration avoids downloading and installing the packages again. This speeds up
+repeated comparisons and reduces unnecessary network traffic.


### PR DESCRIPTION
## Summary
- update README example to create library directories once
- show looping over `sha_compare()` with `install = FALSE` and `quiet = TRUE`
- describe why reusing installations is beneficial
