### PR TITLE
[FEATURE] Add multiple input helper ``sha_compare_many()`` and CLI interface

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,7 +8,12 @@ Encoding: UTF-8
 Imports:
     pak,
     waldo,
-    withr
+    withr,
+    purrr,
+    furrr,
+    optparse,
+    tibble
 Suggests:
     testthat
+Scripts: inst/scripts/regressr_cli.R
 

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,2 +1,3 @@
 export(sha_compare)
 export(print.regressr_result)
+export(sha_compare_many)

--- a/R/sha_compare.R
+++ b/R/sha_compare.R
@@ -16,6 +16,7 @@
 #'   (default `TRUE`).
 #' @param ... Additional arguments passed on to `entry_fun`.
 #' @param diff_fun Function used to diff objects (default `waldo::compare`).
+#' @param diff_args List of additional arguments passed to `diff_fun`.
 #' @return A list with elements `passed`, `diff`, `old`, `new`.
 #' @export
 sha_compare <- function(repo, sha_old, sha_new,
@@ -25,8 +26,9 @@ sha_compare <- function(repo, sha_old, sha_new,
                         lib_old = NULL,
                         lib_new = NULL,
                         install = TRUE,
-                        quiet = TRUE, ...,
-                        diff_fun = waldo::compare) {
+                        quiet = TRUE, ..., 
+                        diff_fun = waldo::compare, 
+                        diff_args = list()) {
   stopifnot(requireNamespace("pak", quietly = TRUE))
   stopifnot(requireNamespace("waldo", quietly = TRUE))
   stopifnot(requireNamespace("withr", quietly = TRUE))
@@ -76,7 +78,7 @@ sha_compare <- function(repo, sha_old, sha_new,
   message("Running ", entry_fun, " on new version...")
   new_res <- run_entry(lib_new)
 
-  diff <- diff_fun(old_res, new_res)
+  diff <- do.call(diff_fun, c(list(old_res, new_res), diff_args))
   passed <- length(diff) == 0L
 
   structure(list(passed = passed,

--- a/R/sha_compare_many.R
+++ b/R/sha_compare_many.R
@@ -1,0 +1,73 @@
+#' Compare multiple inputs or SHAs using `sha_compare()`
+#'
+#' Runs `sha_compare()` over a list of data inputs (and optional argument
+#' lists) and aggregates the results. Optionally executes in parallel using
+#' `furrr`.
+#'
+#' @param repo GitHub repo specification ("owner/pkg").
+#' @param sha_old Base commit SHA/branch/tag.
+#' @param sha_new Character vector of commit SHAs/branches/tags to test.
+#' @param inputs List of data objects passed as the `data` argument.
+#' @param args_list Optional list of lists providing extra arguments for each
+#'   input. Elements are recycled if shorter than `inputs`.
+#' @param pkg Name of the package (defaults to `basename(repo)`).
+#' @param entry_fun Name of exported function to invoke.
+#' @param lib_old Path to library for the old version. Created if `NULL`.
+#' @param lib_new Path to library for the new version. Created if `NULL`.
+#' @param install Logical, whether to install the packages on the first
+#'   iteration.
+#' @param quiet Logical, passed to `sha_compare()`.
+#' @param parallel Either "purrr" (serial) or "furrr" (parallel).
+#' @param diff_fun Diff function passed to `sha_compare()`.
+#' @param diff_args List of additional arguments passed to `diff_fun`.
+#' @return A data frame summarizing the results.
+#' @export
+sha_compare_many <- function(repo, sha_old, sha_new,
+                             inputs, args_list = NULL,
+                             pkg = basename(repo),
+                             entry_fun = "main",
+                             lib_old = NULL, lib_new = NULL,
+                             install = TRUE, quiet = TRUE,
+                             parallel = c("purrr", "furrr"),
+                             diff_fun = waldo::compare,
+                             diff_args = list()) {
+  parallel <- match.arg(parallel)
+
+  mapper <- if (parallel == "furrr") furrr::future_map else purrr::map
+
+  if (is.null(args_list)) args_list <- replicate(length(inputs), list(), simplify = FALSE)
+
+  args_list <- rep(args_list, length.out = length(inputs))
+
+  results <- vector("list", length(inputs))
+
+  for (j in seq_along(sha_new)) {
+    for (i in seq_along(inputs)) {
+      extra <- args_list[[i]]
+      if (!is.list(extra)) extra <- list()
+      results[[i]] <- mapper(1, function(z) {
+        do.call(sha_compare, c(list(
+          repo = repo,
+          sha_old = sha_old,
+          sha_new = sha_new[j],
+          pkg = pkg,
+          entry_fun = entry_fun,
+          data = inputs[[i]],
+          lib_old = lib_old,
+          lib_new = lib_new,
+          install = install && j == 1 && i == 1,
+          quiet = quiet,
+          diff_fun = diff_fun,
+          diff_args = diff_args
+        ), extra))
+      })[[1]]
+    }
+  }
+
+  tibble::tibble(
+    input = seq_along(inputs),
+    passed = vapply(results, function(x) x$passed, logical(1)),
+    diff = lapply(results, "[[", "diff"),
+    result = results
+  )
+}

--- a/README.md
+++ b/README.md
@@ -52,3 +52,36 @@ for (i in seq_along(shas)) {
 Reusing the library directories and setting `install = FALSE` after the first
 iteration avoids downloading and installing the packages again. This speeds up
 repeated comparisons and reduces unnecessary network traffic.
+
+## `sha_compare_many()`
+
+Instead of writing the loop yourself you can use `sha_compare_many()` to run
+the comparison across a list of inputs. Parallel evaluation via **furrr** is
+supported by setting `parallel = "furrr"`.
+
+```r
+inputs <- list(df1, df2)
+args <- list(list(threshold = 0.1), list(threshold = 0.2))
+
+res <- sha_compare_many(
+  repo = "org/pkg",
+  sha_old = "abc123",
+  sha_new = "def456",
+  inputs = inputs,
+  args_list = args,
+  lib_old = old_lib,
+  lib_new = new_lib,
+  parallel = "purrr"
+)
+```
+
+`res` contains a tibble summarising pass/fail status for each input.
+
+## Command line interface
+
+After installing the package you can run comparisons from the command line:
+
+```sh
+Rscript $(R -e 'cat(system.file("scripts", "regressr_cli.R", package="regressr"))') \
+  --repo org/pkg --base main --sha def456 --input data1.rds --input data2.rds
+```

--- a/inst/scripts/regressr_cli.R
+++ b/inst/scripts/regressr_cli.R
@@ -1,0 +1,37 @@
+#!/usr/bin/env Rscript
+
+suppressPackageStartupMessages({
+  library(optparse)
+  library(regressr)
+})
+
+option_list <- list(
+  make_option(c("-r", "--repo"), type = "character", help = "GitHub repo, owner/pkg"),
+  make_option(c("-b", "--base"), type = "character", default = "main",
+              help = "Base SHA [default %default]"),
+  make_option(c("-s", "--sha"), type = "character", action = "append",
+              help = "SHA(s) to compare"),
+  make_option(c("-i", "--input"), type = "character", action = "append",
+              help = "Input data file (RDS). Can be repeated."),
+  make_option(c("-p", "--parallel"), type = "character", default = "purrr",
+              help = "Use purrr or furrr [default %default]")
+)
+
+opt <- parse_args(OptionParser(option_list = option_list))
+
+if (is.null(opt$repo) || is.null(opt$sha) || is.null(opt$input)) {
+  print_help(OptionParser(option_list = option_list))
+  quit(status = 1)
+}
+
+inputs <- lapply(opt$input, readRDS)
+
+res <- sha_compare_many(
+  repo = opt$repo,
+  sha_old = opt$base,
+  sha_new = opt$sha,
+  inputs = inputs,
+  parallel = opt$parallel
+)
+
+print(res)

--- a/tests/testthat/test-cli.R
+++ b/tests/testthat/test-cli.R
@@ -1,0 +1,8 @@
+library(testthat)
+library(regressr)
+cli <- system.file("scripts", "regressr_cli.R", package = "regressr")
+
+test_that("CLI script exists", {
+  skip_if(cli == "")
+  expect_true(file.exists(cli))
+})

--- a/tests/testthat/test-many.R
+++ b/tests/testthat/test-many.R
@@ -1,0 +1,18 @@
+library(testthat)
+library(regressr)
+
+
+test_that("sha_compare_many runs", {
+  skip_if_offline()
+  inputs <- list(data.frame(x = 1:3), data.frame(x = 3:1))
+  res <- sha_compare_many(
+    repo = "org/pkg",
+    sha_old = Sys.getenv("SHA_BASE", "main"),
+    sha_new = Sys.getenv("SHA_NEW", "HEAD"),
+    inputs = inputs,
+    pkg = "pkg",
+    entry_fun = "main",
+    parallel = "purrr"
+  )
+  expect_true(all(res$passed))
+})


### PR DESCRIPTION
## Summary
- add `sha_compare_many()` to run `sha_compare()` across many inputs in serial or parallel
- allow extra `diff_args` to be passed into `sha_compare`
- provide command-line interface script for regression checks
- document the new helper and CLI
- tests for new functionality
