### PR TITLE
[REFACTOR] Add helper ``sha_install_versions()`` to install package versions

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,3 +1,4 @@
 export(sha_compare)
 export(print.regressr_result)
 export(sha_compare_many)
+export(sha_install_versions)

--- a/R/sha_compare.R
+++ b/R/sha_compare.R
@@ -11,7 +11,9 @@
 #' @param lib_new Path to library for the new version. If `NULL` a
 #'   temporary directory is used.
 #' @param install Logical, whether to install the package versions
-#'   before running (default `TRUE`).
+#'   before running (default `TRUE`). When `TRUE`,
+#'   [sha_install_versions()] installs the packages into
+#'   `lib_old` and `lib_new`.
 #' @param quiet Logical, whether to suppress messages from `pak::pkg_install`
 #'   (default `TRUE`).
 #' @param ... Additional arguments passed on to `entry_fun`.
@@ -33,24 +35,22 @@ sha_compare <- function(repo, sha_old, sha_new,
   stopifnot(requireNamespace("waldo", quietly = TRUE))
   stopifnot(requireNamespace("withr", quietly = TRUE))
 
-  if (is.null(lib_old)) lib_old <- tempfile("regressr_old_")
-  if (is.null(lib_new)) lib_new <- tempfile("regressr_new_")
-  dir.create(lib_old, recursive = TRUE, showWarnings = FALSE)
-  dir.create(lib_new, recursive = TRUE, showWarnings = FALSE)
-
   if (install) {
-    message("Installing old and new versions...")
-
-    install_pkgs <- function() {
-      pak::pkg_install(paste0(repo, "@", sha_old), lib = lib_old, ask = FALSE)
-      pak::pkg_install(paste0(repo, "@", sha_new), lib = lib_new, ask = FALSE)
-    }
-
-    if (quiet) {
-      suppressMessages(install_pkgs())
-    } else {
-      install_pkgs()
-    }
+    libs <- sha_install_versions(
+      repo = repo,
+      sha_old = sha_old,
+      sha_new = sha_new,
+      lib_old = lib_old,
+      lib_new = lib_new,
+      quiet = quiet
+    )
+    lib_old <- libs$lib_old
+    lib_new <- libs$lib_new
+  } else {
+    if (is.null(lib_old)) lib_old <- tempfile("regressr_old_")
+    if (is.null(lib_new)) lib_new <- tempfile("regressr_new_")
+    dir.create(lib_old, recursive = TRUE, showWarnings = FALSE)
+    dir.create(lib_new, recursive = TRUE, showWarnings = FALSE)
   }
 
   extra_args <- list(...)

--- a/R/sha_install_versions.R
+++ b/R/sha_install_versions.R
@@ -1,0 +1,39 @@
+#' Install two SHAs of a GitHub package
+#'
+#' Installs the `sha_old` and `sha_new` versions of a package into
+#' separate library directories. Directories are created when `NULL` and
+#' the paths are returned invisibly.
+#'
+#' @param repo GitHub repo specification ("owner/pkg").
+#' @param sha_old Base commit SHA or branch/tag.
+#' @param sha_new Commit SHA or branch/tag to test.
+#' @param lib_old Library directory for the old version; created if `NULL`.
+#' @param lib_new Library directory for the new version; created if `NULL`.
+#' @param quiet Logical; suppress messages from `pak::pkg_install`.
+#' @return Invisibly, a list with `lib_old` and `lib_new`.
+#' @export
+sha_install_versions <- function(repo, sha_old, sha_new,
+                                 lib_old = NULL, lib_new = NULL,
+                                 quiet = TRUE) {
+  stopifnot(requireNamespace("pak", quietly = TRUE))
+
+  if (is.null(lib_old)) lib_old <- tempfile("regressr_old_")
+  if (is.null(lib_new)) lib_new <- tempfile("regressr_new_")
+  dir.create(lib_old, recursive = TRUE, showWarnings = FALSE)
+  dir.create(lib_new, recursive = TRUE, showWarnings = FALSE)
+
+  install_pkgs <- function() {
+    pak::pkg_install(paste0(repo, "@", sha_old),
+                     lib = lib_old, ask = FALSE)
+    pak::pkg_install(paste0(repo, "@", sha_new),
+                     lib = lib_new, ask = FALSE)
+  }
+
+  if (quiet) {
+    suppressMessages(install_pkgs())
+  } else {
+    install_pkgs()
+  }
+
+  invisible(list(lib_old = lib_old, lib_new = lib_new))
+}

--- a/README.md
+++ b/README.md
@@ -19,39 +19,31 @@ pak::pkg_install("ddarmon/regressr")
 ```r
 library(regressr)
 
-# Directories used to install the package versions
-old_lib <- tempfile("regressr_old_")
-new_lib <- tempfile("regressr_new_")
-dir.create(old_lib)
-dir.create(new_lib)
+# Install the two versions once
+libs <- sha_install_versions(
+  repo = "org/pkg",
+  sha_old = "abc123",
+  sha_new = "def456"
+)
 
-# SHAs to compare against a baseline commit
-shas <- c("def456", "ghi789")
-for (i in seq_along(shas)) {
-  res <- sha_compare(
-    repo = "org/pkg",
-    sha_old = "abc123",   # baseline commit
-    sha_new = shas[i],     # comparison commit
-    pkg = "pkg",
-    entry_fun = "main",
-    data = data.frame(x = 1:3),
-    old_lib = old_lib,
-    new_lib = new_lib,
-    install = i == 1,      # reuse installs after first iteration
-    quiet = TRUE
-  )
+res <- sha_compare(
+  repo = "org/pkg",
+  sha_old = "abc123",
+  sha_new = "def456",
+  lib_old = libs$lib_old,
+  lib_new = libs$lib_new,
+  install = FALSE
+)
 
-  if (res$passed) {
-    print("Objects identical")
-  } else {
-    print(res$diff)
-  }
+if (res$passed) {
+  print("Objects identical")
+} else {
+  print(res$diff)
 }
 ```
 
-Reusing the library directories and setting `install = FALSE` after the first
-iteration avoids downloading and installing the packages again. This speeds up
-repeated comparisons and reduces unnecessary network traffic.
+Installing once and reusing the library directories avoids repeated downloads
+and speeds up comparisons.
 
 ## `sha_compare_many()`
 
@@ -69,8 +61,8 @@ res <- sha_compare_many(
   sha_new = "def456",
   inputs = inputs,
   args_list = args,
-  lib_old = old_lib,
-  lib_new = new_lib,
+  lib_old = libs$lib_old,
+  lib_new = libs$lib_new,
   parallel = "purrr"
 )
 ```


### PR DESCRIPTION
## Summary
- add `sha_install_versions()` helper
- use helper in `sha_compare()` and `sha_compare_many()`
- document usage in README
- export new function
